### PR TITLE
Adds an 'update' command to the cry scripts that automatically pulls submodules

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1072,7 +1072,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = README.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/Scripts/bet.py
+++ b/Scripts/bet.py
@@ -1,8 +1,9 @@
 import sys
 import argparse
 
-from build import build
+from update import update
 from clean import clean
+from build import build
 from tests import tests, compile_tests
 from cc import gen_cc
 from utils import bet_log
@@ -19,6 +20,7 @@ def main():
     parser = argparse.ArgumentParser(description='bet (before even trying) - the sad engine scripting pipeline')
 
     # Initialize command line arguments
+    parser.add_argument('--update', action=argparse.BooleanOptionalAction, help='updates the project\'s dependencies and submodules')
     parser.add_argument('--clean', action=argparse.BooleanOptionalAction, help='cleans the project of auto-generated premake files')
     parser.add_argument('--build', nargs="?", const="vs2022", metavar='toolset', type=str, help='build the premake project (toolsets: vs2022 [default], vs2019, or gmake2)')
     parser.add_argument('--tests', action=argparse.BooleanOptionalAction, help='tries to run the sad testbed')
@@ -32,6 +34,8 @@ def main():
         return
 
     # Execute operations for passed arguments
+    if args.update is not None:
+        update()
     if args.clean is not None:
         clean()
     if args.build is not None:

--- a/Scripts/update.py
+++ b/Scripts/update.py
@@ -1,0 +1,20 @@
+import os
+import subprocess
+
+from utils import bet_log, bet_err
+from constants import SUBPROCESS_USE_SHELL
+
+"""
+Performs a recursive update on project and its submodules
+Ideally this gets run on project setup
+
+TODO: Research git hooks for cloning? Or anstract this into a setup.py script
+"""
+def update():
+    bet_log(f"Recursively updating project and its submodules")
+    update_cmd = subprocess.run(["git", "submodule", "update", "--init", "--recursive"], shell=SUBPROCESS_USE_SHELL)
+
+    if update_cmd.returncode == 0:
+        bet_log("bet! Successfully updated project project dependencies and submodules.")
+    else:
+        bet_err("Uh oh, awkward... something went wrong while updating the project submodules.")

--- a/cry.bat
+++ b/cry.bat
@@ -6,6 +6,9 @@
 :: Note: Should be run from the root of the repository
 ::
 
+:: Check for submodule updates (this can be commented if it's slowing things down)
+CALL :update "%~dp0"
+
 :: Clean previous premake artifacts
 CALL :clean "%~dp0"
 
@@ -21,6 +24,10 @@ CALL :build "%~dp0"
 :: Optional: Run the project
 :: CALL :execute "%~dp0"
 
+GOTO :eof
+
+:update
+CALL python3 %~f1\Scripts\bet.py --update
 GOTO :eof
 
 :clean

--- a/cry.sh
+++ b/cry.sh
@@ -6,6 +6,9 @@
 ## Note: Should be run from the root of the repository
 ##
 
+# Update project submodules and dependencies (this can be commented if it's slowing things down)
+python3 ./Scripts/bet.py --update
+
 # Clean previous premake artifacts
 python3 ./Scripts/bet.py --clean
 
@@ -18,5 +21,5 @@ make
 # Optional: Run the unit tests
 # python3 ./Scripts/bet.py --tests
 
-# Optional: Run the project 
+# Optional: Run the project
 ./Build/Bin/Game/Game.app


### PR DESCRIPTION
### Description
Hotfix for the `cry` scripts to automatically recurse submodules when necessary.

### Trello Ticket
n/a

### Additional Info
The actual cloning of submodules shouldn't happen constantly - maybe once everytime you pull. If this heavily impacts the performance of running `cry.bat` or `cry.sh` we can definitely comment it out. On my machines this works fine on multiple runs - but we can see how it plays out over the next couple weeks.

I decided to add this so people didn't have to keep track of when to run the `git submodule...` commands. Everything should happen automatically now. 👍 